### PR TITLE
enable utf-8 encoding when reading the languages

### DIFF
--- a/homoglyphs/core.py
+++ b/homoglyphs/core.py
@@ -118,7 +118,7 @@ class Languages:
 
     @classmethod
     def get_all(cls):
-        with open(cls.fpath) as f:
+        with open(cls.fpath, encoding='utf-8') as f:
             data = json.load(f)
         return set(data.keys())
 


### PR DESCRIPTION
Not all alphabets are available ascii table. So, we have to make sure that utf-8 encodxing is available.